### PR TITLE
fix branch name utf-8 encoding probrem.

### DIFF
--- a/gitk
+++ b/gitk
@@ -1780,11 +1780,15 @@ proc readrefs {} {
     global otherrefids idotherrefs mainhead mainheadid
     global selecthead selectheadid
     global hideremotes
+    global tclencoding
 
     foreach v {tagids idtags headids idheads otherrefids idotherrefs} {
 	unset -nocomplain $v
     }
     set refd [open [list | git show-ref -d] r]
+    if {$tclencoding != {}} {
+	fconfigure $refd -encoding $tclencoding
+    }
     while {[gets $refd line] >= 0} {
 	if {[string index $line 40] ne " "} continue
 	set id [string range $line 0 39]


### PR DESCRIPTION
fix probrem .

branch name `顧客`

![image](https://user-images.githubusercontent.com/5441449/70166325-e0af0d80-1707-11ea-95a9-983bbb9eb9b1.png)

![image](https://user-images.githubusercontent.com/5441449/70166398-04725380-1708-11ea-9c66-1ecc0508c84a.png)
