### PR TITLE
fix branch name encoding error on gitk.

### DIFF
--- a/gitk
+++ b/gitk
@@ -1780,11 +1780,15 @@ proc readrefs {} {
     global otherrefids idotherrefs mainhead mainheadid
     global selecthead selectheadid
     global hideremotes
+    global tclencoding
 
     foreach v {tagids idtags headids idheads otherrefids idotherrefs} {
 	unset -nocomplain $v
     }
     set refd [open [list | git show-ref -d] r]
+    if {$tclencoding != {}} {
+	fconfigure $refd -encoding $tclencoding
+    }
     while {[gets $refd line] >= 0} {
 	if {[string index $line 40] ne " "} continue
 	set id [string range $line 0 39]


### PR DESCRIPTION
git checkout -b '漢字'
gitk show branch name broken like this '貍｢蟄'
fix this problem.

Signed-off-by: Kazuhiro Kato <kato-k@ksysllc.co.jp>